### PR TITLE
fix test app plugin

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>UnusedPrivateProperty:TestAppPlugin.kt$MinirogueTestAppExtension$project: Project</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/src/main/kotlin/plugin/TestAppPlugin.kt
+++ b/src/main/kotlin/plugin/TestAppPlugin.kt
@@ -37,4 +37,4 @@ public class TestAppPlugin : Plugin<Project> {
     }
 }
 
-public open class MinirogueTestAppExtension
+public open class MinirogueTestAppExtension(project: Project)


### PR DESCRIPTION
There was an issue with the test app plugin where it attempts to create an extension with a constructor argument that doesn't exist. The constructor argument has been restored, as it is expected to be used in the future.