### PR TITLE
remove context parameters compiler argument

### DIFF
--- a/src/main/kotlin/configuration/UniversalConfiguration.kt
+++ b/src/main/kotlin/configuration/UniversalConfiguration.kt
@@ -25,7 +25,6 @@ internal fun Project.applyUniversalConfigurations(universalConfiguration: Univer
     configureAddScriptsTask(universalConfiguration.addScriptsTaskConfiguration)
     extensions.configure(HasConfigurableKotlinCompilerOptions::class.java) {
         compilerOptions {
-            freeCompilerArgs.add("-Xcontext-parameters")
             freeCompilerArgs.add("-Xexpect-actual-classes")
         }
     }


### PR DESCRIPTION
it's stable in Kotlin 2.4, which is delivered with these plugins